### PR TITLE
emoji-unicode-map 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# emoji-unicode-map [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/emoji-unicode-map.svg)](https://www.npmjs.com/package/emoji-unicode-map) [![Downloads](https://img.shields.io/npm/dt/emoji-unicode-map.svg)](https://www.npmjs.com/package/emoji-unicode-map) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# emoji-unicode-map
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/emoji-unicode-map.svg)](https://www.npmjs.com/package/emoji-unicode-map) [![Downloads](https://img.shields.io/npm/dt/emoji-unicode-map.svg)](https://www.npmjs.com/package/emoji-unicode-map) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Unicode to name emoji mapping.
 
@@ -48,12 +50,6 @@ Gets the emoji name, by providing the character.
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## :dizzy: Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
-
-
- - [`emoji-chars`](https://github.com/IonicaBizau/emoji-chars#readme)—Get the emoji chars as array.
- - [`emoji-dictionary`](https://github.com/IonicaBizau/emoji-dictionary#readme)—Convert emoji names in unicode characters and vice versa.
 
 ## :scroll: License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-unicode-map",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Unicode to name emoji mapping.",
   "main": "lib/index.js",
   "directories": {
@@ -39,6 +39,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
